### PR TITLE
⚠️ Agregar warning sobre sincronizar fork en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ Toda la documentación, guías, ejercicios y tutoriales están en:
 
 ---
 
+## ⚠️ IMPORTANTE: Mantén tu Fork Actualizado
+
+> **Si ya hiciste fork del repositorio, lee esto:**
+>
+> Durante el curso agregaré **nuevos ejercicios constantemente**. Tu fork NO se actualiza automáticamente.
+>
+> **👉 [Guía completa de sincronización →](https://todoeconometria.github.io/ejercicios-bigdata/git-github/sincronizar-fork/#el-problema)**
+>
+> **Resumen rápido:**
+> ```bash
+> git fetch upstream
+> git merge upstream/main
+> ```
+>
+> **¿No funciona?** Lee la guía completa arriba - tiene diagramas paso a paso.
+
+---
+
 ## 🎯 ¿Qué Aprenderás?
 
 ### El Problema Común


### PR DESCRIPTION
## Cambio

Agrega sección de warning visible en README.md para recordar a los alumnos que deben sincronizar su fork.

**Ubicación:** Justo después de "Inicio Rápido", antes de "¿Qué Aprenderás?"

**Incluye:**
- ⚠️ Warning visual destacado
- Link directo a guía completa: https://todoeconometria.github.io/ejercicios-bigdata/git-github/sincronizar-fork/#el-problema
- Resumen rápido de comandos
- Mensaje claro: fork NO se actualiza automáticamente

**Vista previa:**
> ⚠️ IMPORTANTE: Mantén tu Fork Actualizado
> 
> Durante el curso agregaré nuevos ejercicios constantemente. Tu fork NO se actualiza automáticamente.
> 
> 👉 Guía completa de sincronización →

Asegura que ningún alumno se pierda ejercicios nuevos por no sincronizar.